### PR TITLE
[GH-28] Correct syntax in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ Here is an example of a hello world workflow.
 
 ```groovy
 process sayHello {
-  executor = 'float'
-  image = 'cactus'
-  cpu = 2
-  mem = 4
+  executor 'float'
+  container 'cactus'
+  cpus 2
+  memory '4 G'
 
   output:
     stdout


### PR DESCRIPTION
The example in README does not properly set the property of process.

Since we have support the process configuration, change the sample to align to the DSL syntax.