### PR TITLE
[GH-37] Support default registry.

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
@@ -16,7 +16,9 @@
 package com.memverge.nextflow
 
 import groovy.transform.CompileStatic
+import groovy.transform.Memoized
 import nextflow.exception.AbortOperationException
+import nextflow.processor.TaskRun
 import nextflow.util.MemoryUnit
 import org.apache.commons.lang.StringUtils
 

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
@@ -35,7 +35,7 @@ class FloatJobs {
     private String taskPrefix
 
     FloatJobs(Collection<String> ocAddresses) {
-        if (ocAddresses.size() == 0) {
+        if (!ocAddresses) {
             throw new IllegalArgumentException('op-center address is empty')
         }
         job2status = new ConcurrentHashMap<>()

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -592,4 +592,46 @@ class FloatGridExecutorTest extends Specification {
         setEnv('MMC_USERNAME', '')
         setEnv('MMC_PASSWORD', '')
     }
+
+    def "get image with default registry"() {
+        given:
+        def exec = newTestExecutor(
+                [podman : [registry: 'quay.io'],
+                 process: [address: addr]])
+        def task = [:] as TaskRun
+
+        when:
+        task.config = ['image': image] as TaskConfig
+
+        then:
+        exec.getImage(task) == "quay.io/$image"
+    }
+
+    def "get image without default registry"() {
+        given:
+        def exec = newTestExecutor(
+                [process: [address: addr]])
+        def task = [:] as TaskRun
+
+        when:
+        task.config = ['image': image] as TaskConfig
+
+        then:
+        exec.getImage(task) == "$image"
+    }
+
+    def "get image with default registry and specific image"() {
+        given:
+        def exec = newTestExecutor(
+                [podman : [registry: 'quay.io'],
+                 process: [address: addr]])
+        def task = [:] as TaskRun
+        def dImage = "docker.io/$image"
+
+        when:
+        task.config = ['image': dImage] as TaskConfig
+
+        then:
+        exec.getImage(task) == dImage
+    }
 }


### PR DESCRIPTION
When user set `docker.registry` or `podman.registry`, use this registry as the default registry.

Use the default registry configured by MMC if they are not available.