### PR TITLE
Fusion support

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatTaskHandler.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatTaskHandler.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.executor.GridTaskHandler
 import nextflow.processor.TaskRun
+
 /**
  * Float task handler
  */
@@ -38,7 +39,7 @@ class FloatTaskHandler extends GridTaskHandler {
     protected ProcessBuilder createProcessBuilder() {
 
         // -- log the submit command
-        final cli = executor.getSubmitCommandLine(task, wrapperFile)
+        final cli = ((FloatGridExecutor)executor).getSubmitCommandLine(this, wrapperFile)
         log.trace "start process ${task.name} > cli: ${cli}"
 
         // -- prepare submit process
@@ -51,6 +52,14 @@ class FloatTaskHandler extends GridTaskHandler {
         }
 
         return builder
+    }
+
+    /**
+     * Override the grid task handler to make the fusion launcher
+     * script container-native.
+     */
+    protected String fusionStdinWrapper() {
+        return '#!/bin/bash\n' + fusionSubmitCli().join(' ') + '\n'
     }
 
 }


### PR DESCRIPTION
Experimenting with Fusion support. The main changes are:
- don't mount any S3 buckets, Fusion will handle that at runtime
- use Fusion launcher script instead of `.command.run`
- add Fusion environment variables (not sure if I'm doing this correctly)

To test it, simply add the following config options:
```groovy
wave.enabled = true
fusion.enabled = true
```

Currently I'm hitting this error:
```
Caused by:
  Failed to submit process to grid scheduler for execution

Command executed:

  cat << 'LAUNCH_COMMAND_EOF' | float [...] sbatch --image wave.seqera.io/wt/175a12eb66fb/nextflow/bash:latest --cpu 1 --mem 1 --job /tmp/nextflow15874410106323735449.command.run --env FUSION_WORK=/fusion/s3/nf-ireland/work/40/a9daa6838b4303491444df558df99c,FUSION_TAGS=[.command.*|.exitcode|.fusion.*](nextflow.io/metadata=true),[*](nextflow.io/temporary=true) --customTag nf-job-id:3l53vh-4
  #!/bin/bash
  /usr/bin/fusion bash /fusion/s3/nf-ireland/work/40/a9daa6838b4303491444df558df99c/.command.run
  LAUNCH_COMMAND_EOF

Command exit status:
  1

Command output:
  Error: Resource not found, cannot find image: wave.seqera.io/wt/175a12eb66fb/nextflow/bash:latest (code: 1002)
```