### PR TITLE
Add support for several process directives

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
@@ -44,6 +44,8 @@ class FloatConf {
     String s3secretKey
 
     /** parameters for submitting the tasks */
+    String vmPolicy
+    String migratePolicy
     String commonExtra
 
     /**
@@ -118,6 +120,13 @@ class FloatConf {
                     .findAll { it.size() > 0 }
         }
         this.nfs = floatNode.nfs
+
+        if (floatNode.vmPolicy) {
+            this.vmPolicy = collapseMapToString(floatNode.vmPolicy as Map)
+        }
+        if (floatNode.migratePolicy) {
+            this.migratePolicy = collapseMapToString(floatNode.migratePolicy as Map)
+        }
         this.commonExtra = floatNode.commonExtra
 
         if (floatNode.cpu)
@@ -134,13 +143,22 @@ class FloatConf {
             warnDeprecated("float.container", "process.container")
     }
 
-    private static def warnDeprecated(String deprecated, String replacement) {
+    private String collapseMapToString(Map map) {
+        final collapsedStr = map
+                .toConfigObject()
+                .flatten()
+                .collect( (k, v) -> "${k}=${v}" )
+                .join(',')
+        return "[${collapsedStr}]"
+    }
+
+    private static void warnDeprecated(String deprecated, String replacement) {
         log.warn "[float] config option `$deprecated` " +
                 "is no longer supported, " +
                 "use `$replacement` instead"
     }
 
-    private def initAwsConf(Map conf) {
+    private void initAwsConf(Map conf) {
         def cred = Global.getAwsCredentials(System.getenv(), conf)
         if (cred && cred.size() > 1) {
             s3accessKey = cred[0]

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
@@ -94,6 +94,7 @@ class FloatBaseTest extends BaseTest {
         task.id = taskID
         task.index = taskSerial.incrementAndGet()
         task.workDir = Paths.get(workDir)
+        task.name = "foo (${task.index})"
         return task
     }
 

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatConfTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatConfTest.groovy
@@ -186,4 +186,26 @@ class FloatConfTest extends BaseTest {
         then:
         volume == 'nfs://1.2.3.4/work/dir:/local'
     }
+
+    def "get vm policy from config"() {
+        expect:
+        FloatConf.getConf([float: [vmPolicy: CONF]]).vmPolicy == STR
+
+        where:
+        CONF                                              | STR
+        [spotOnly:true,retryLimit:10,retryInterval:'30s'] | '[spotOnly=true,retryLimit=10,retryInterval=30s]'
+        [spotOnly:true,priceLimit:0.1]                    | '[spotOnly=true,priceLimit=0.1]'
+    }
+
+    def "get migrate policy from config"() {
+        expect:
+        FloatConf.getConf([float: [migratePolicy: CONF]]).migratePolicy == STR
+
+        where:
+        CONF                                                | STR
+        [disable:true]                                      | '[disable=true]'
+        [cpu:[upperBoundRatio:90,upperBoundDuration:'10s']] | '[cpu.upperBoundRatio=90,cpu.upperBoundDuration=10s]'
+        [cpu:[lowerBoundRatio:30],mem:[upperBoundRatio:90]] | '[cpu.lowerBoundRatio=30,mem.upperBoundRatio=90]'
+        [cpu:[step:50]]                                     | '[cpu.step=50]'
+    }
 }

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -269,13 +269,73 @@ class FloatGridExecutorTest extends FloatBaseTest {
         cmd.join(' ') == expected.join(' ')
     }
 
+    def "use machine type directive"() {
+        given:
+        final exec = newTestExecutor()
+        final task = newTask(exec, new TaskConfig(
+                container: image,
+                machineType: 't2.xlarge',
+        ))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd.join(' ').contains('--instType t2.xlarge')
+    }
+
+    def "use disk directive"() {
+        given:
+        final exec = newTestExecutor()
+        final task = newTask(exec, new TaskConfig(
+                container: image,
+                disk: '40G',
+        ))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd.join(' ').contains('--rootVolSize 40')
+    }
+
+    def "use time directive"() {
+        given:
+        final exec = newTestExecutor()
+        final task = newTask(exec, new TaskConfig(
+                container: image,
+                time: '24h',
+        ))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd.join(' ').contains('--timeLimit 86400s')
+    }
+
+    def "use resourceLabels directive"() {
+        given:
+        final exec = newTestExecutor()
+        final task = newTask(exec, new TaskConfig(
+                container: image,
+                resourceLabels: [foo: 'bar'],
+        ))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd.join(' ').contains('--customTag foo:bar')
+    }
+
     private def taskStatus(int i, String st) {
         return """
-            {                                                           
-                "id": "task$i",                          
-                "name": "tJob-$i",                                                                                            
-                "user": "admin",                                        
-                "imageID": "docker.io/memverge/cactus:latest",          
+            {
+                "id": "task$i",
+                "name": "tJob-$i",
+                "user": "admin",
+                "imageID": "docker.io/memverge/cactus:latest",
                 "status": "$st",
                 "customTags": {
                     "nf-job-id": "tJob-$i"


### PR DESCRIPTION
Close #27 

This PR adds support for the following process directives:
- disk
- machineType
- resourceLabels
- time

While the CLI options can already be specified via `float.commonExtra`, the process directives are more user-friendly and can also be applied on a per-process level.

Also adds custom config options for `--vmPolicy` and `--migratePolicy`, since these options are some of the most valuable parts of Float but also have the most complicated syntax, we should try to make them as user-friendly as possible.

I also added a few default labels for things like process name, task name, session ID, etc. But feel free to remove them if you don't think they are needed. I copied them from the K8s executor.

I added unit tests for these options but haven't tested them end to end. Let me know if you need any help with testing.

Not urgent or groundbreaking but these settings would be nice to have for the initial blog post.