### PR TITLE
[GH-54] Support `extraOptions` of float

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
@@ -50,6 +50,7 @@ class FloatConf {
     /** parameters for submitting the tasks */
     String vmPolicy
     String migratePolicy
+    String extraOptions
     String commonExtra
 
     /**
@@ -131,6 +132,9 @@ class FloatConf {
         if (floatNode.migratePolicy) {
             this.migratePolicy = collapseMapToString(floatNode.migratePolicy as Map)
         }
+        if (floatNode.extraOptions) {
+            this.extraOptions = floatNode.extraOptions as String
+        }
         this.commonExtra = floatNode.commonExtra
 
         if (floatNode.cpu)
@@ -151,7 +155,7 @@ class FloatConf {
         final collapsedStr = map
                 .toConfigObject()
                 .flatten()
-                .collect( (k, v) -> "${k}=${v}" )
+                .collect((k, v) -> "${k}=${v}")
                 .join(',')
         return "[${collapsedStr}]"
     }

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -308,6 +308,9 @@ class FloatGridExecutor extends AbstractGridExecutor {
         if (floatConf.migratePolicy) {
             cmd << '--migratePolicy' << floatConf.migratePolicy
         }
+        if (floatConf.extraOptions) {
+            cmd << '--extraOptions' << floatConf.extraOptions
+        }
         cmd.addAll(getExtra(task))
         log.info "[float] submit job: ${toLogStr(cmd)}"
         return cmd

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -314,6 +314,25 @@ class FloatGridExecutorTest extends FloatBaseTest {
         cmd.join(' ').contains('--timeLimit 86400s')
     }
 
+    def "use extra options"() {
+        given:
+        final option = """--external 'mnt[]:sm'"""
+        final exec = newTestExecutor([
+                float: [address     : addr,
+                        username    : user,
+                        password    : pass,
+                        nfs         : nfs,
+                        extraOptions: option]])
+        final task = newTask(exec)
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd.contains('--extraOptions')
+        cmd.contains(option)
+    }
+
     def "use resourceLabels directive"() {
         given:
         final exec = newTestExecutor()


### PR DESCRIPTION
Extra options can be supplied as an array.  The option value may contain space. It would break the command if it was added in the `extraCommon` option directly.

Add that option support the `float` scope.

Closes GH-54.