### PR TITLE
[GH-56] add `timeFactor` in float conf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Just make sure you have proper internet access.
 
 ```groovy
 plugins {
-    id 'nf-float@0.3.0'
+    id 'nf-float@0.3.1'
 }
 ```
 
@@ -66,9 +66,9 @@ Go to the folder where you just install the `nextflow` command line.
 Let's call this folder the Nextflow home directory.
 Create the float plugin folder with:
 ```bash
-mkdir -p .nextflow/plugins/nf-float-0.3.0
+mkdir -p .nextflow/plugins/nf-float-0.3.1
 ```
-where `0.3.0` is the version of the float plugin.  This version number should 
+where `0.3.1` is the version of the float plugin.  This version number should 
 align with the version in of your plugin and the property in your configuration
 file. (check the configuration section)
 
@@ -76,7 +76,7 @@ Retrieve your plugin zip file and unzip it in this folder.
 If everything goes right, you should be able to see two sub-folders:
 
 ```bash
-$ ll .nextflow/plugins/nf-float-0.3.0/
+$ ll .nextflow/plugins/nf-float-0.3.1/
 total 48
 drwxr-xr-x 4 ec2-user ec2-user    51 Jan  5 07:17 classes
 drwxr-xr-x 2 ec2-user ec2-user    25 Jan  5 07:17 META-INF
@@ -89,7 +89,7 @@ file with the command line option `-c`.  Here is a sample of the configuration.
 
 ```groovy
 plugins {
-    id 'nf-float@0.3.0'
+    id 'nf-float@0.3.1'
 }
 
 workDir = '/mnt/memverge/shared'
@@ -122,6 +122,8 @@ Available `float` config options:
               the CLI usage for the list of available options.
 * `vmPolicy`: the VM creation policy, specified as a map.  Refer to the CLI usage
               for the list of available options.
+* `timeFactor`: a float number.  default to 1.  An extra factor to multiply based 
+  on the time supplied by the task.  Use it to resolve some task timeouts.
 * `commonExtra`: allows the user to specify other submit CLI options.  This parameter
                  will be appended to every float submit command.
 
@@ -165,7 +167,7 @@ Unknown config secret 'MMC_USERNAME'
 To enable s3 as work directory, user need to set work directory to a s3 bucket.
 ```groovy
 plugins {
-    id 'nf-float@0.3.0'
+    id 'nf-float@0.3.1'
 }
 
 workDir = 's3://bucket/path'

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
@@ -53,6 +53,8 @@ class FloatConf {
     String extraOptions
     String commonExtra
 
+    float timeFactor = 1
+
     /**
      * Create a FloatConf instance and initialize the content from the
      * configuration.  The configuration should contain a "float" node.
@@ -134,6 +136,9 @@ class FloatConf {
         }
         if (floatNode.extraOptions) {
             this.extraOptions = floatNode.extraOptions as String
+        }
+        if (floatNode.timeFactor) {
+            this.timeFactor = floatNode.timeFactor as Float
         }
         this.commonExtra = floatNode.commonExtra
 

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -300,7 +300,9 @@ class FloatGridExecutor extends AbstractGridExecutor {
         }
         addVolSize(cmd, task)
         if (task.config.getTime()) {
-            cmd << '--timeLimit' << "${task.config.getTime().toSeconds()}s".toString()
+            Float seconds = task.config.getTime().toSeconds()
+            seconds *= floatConf.timeFactor
+            cmd << '--timeLimit' << "${seconds.toInteger()}s".toString()
         }
         if (floatConf.vmPolicy) {
             cmd << '--vmPolicy' << floatConf.vmPolicy

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.3.0
+Plugin-Version: 0.3.1
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=23.04.0

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -314,6 +314,26 @@ class FloatGridExecutorTest extends FloatBaseTest {
         cmd.join(' ').contains('--timeLimit 86400s')
     }
 
+    def "use timeout factor"() {
+        given:
+        final exec = newTestExecutor(
+                [float: [address    : addr,
+                         username   : user,
+                         password   : pass,
+                         nfs        : nfs,
+                         timeFactor: 1.1]])
+        final task = newTask(exec, new TaskConfig(
+                container: image,
+                time: '1h',
+        ))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd.join(' ').contains('--timeLimit 3960s')
+    }
+
     def "use extra options"() {
         given:
         final option = """--external 'mnt[]:sm'"""


### PR DESCRIPTION
One task in the full test profile of nf-core/sarek keeps reporting timeout. To work around this issue, add an extra `timeFactor` to scale the default timeout for the MMC platform.

Closes GH-56.