### PR TITLE
Refresh the workDir if not empty.

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -509,7 +509,11 @@ class FloatGridExecutor extends AbstractGridExecutor {
         log.debug "[float] task id: $taskId, nf-job-id: $job.nfJobID, " +
                 "float-job-id: $job.floatJobID, " +
                 "float status: $job.status, nf status: $st"
-        return st == QueueStatus.DONE || st == QueueStatus.ERROR
+        boolean finished = st == QueueStatus.DONE || st == QueueStatus.ERROR
+        if (finished) {
+            floatJobs.refreshWorkDir(job.nfJobID)
+        }
+        return finished
     }
 
     static private Map<String, QueueStatus> STATUS_MAP = [

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
@@ -84,6 +84,14 @@ class FloatJobs {
         return job.status
     }
 
+    def refreshWorkDir(String nfJobID) {
+        def workDir = nfJobID2workDir.get(nfJobID)
+        if (workDir) {
+            // call list files to update the folder cache
+            FileHelper.listDirectory(workDir)
+        }
+    }
+
     @WithWriteLock
     def updateOcStatus(String oc, String text) {
         def stMap = FloatJob.parseJobMap(text)
@@ -96,8 +104,7 @@ class FloatJobs {
             def workDir = nfJobID2workDir.get(job.nfJobID)
             if (workDir) {
                 // check the availability of result files
-                // call list files to update the folder cache
-                FileHelper.listDirectory(workDir)
+                refreshWorkDir(job.nfJobID)
                 def files = ['.command.out', '.command.err', '.exitcode']
                 if (currentSt != Completed && job.status == Completed) {
                     for (filename in files) {


### PR DESCRIPTION
For some shared file system, we need to refresh the work directory before we access the files in this folder.  The refresh operation makes sure the content of the folder is updated.