### PR TITLE
[GH-72] Disable `re-run` by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,20 @@ Just make sure you have proper internet access.
 
 ```groovy
 plugins {
+    id 'nf-float'
+}
+```
+
+This will download the latest version of the plugin.
+
+If you need a specific version, you can specify the version number like this:
+
+```groovy
+plugins {
     id 'nf-float@0.4.1'
 }
 ```
+
 
 #### Manual Install
 
@@ -66,9 +77,9 @@ Go to the folder where you just install the `nextflow` command line.
 Let's call this folder the Nextflow home directory.
 Create the float plugin folder with:
 ```bash
-mkdir -p .nextflow/plugins/nf-float-0.4.1
+mkdir -p .nextflow/plugins/nf-float-<version>
 ```
-where `0.4.1` is the version of the float plugin.  This version number should 
+where `<version>` is the version of the float plugin, such as `0.4.1`.  This version number should 
 align with the version in of your plugin and the property in your configuration
 file. (check the configuration section)
 
@@ -76,7 +87,7 @@ Retrieve your plugin zip file and unzip it in this folder.
 If everything goes right, you should be able to see two sub-folders:
 
 ```bash
-$ ll .nextflow/plugins/nf-float-0.4.1/
+$ ll .nextflow/plugins/nf-float-<version>/
 total 48
 drwxr-xr-x 4 ec2-user ec2-user    51 Jan  5 07:17 classes
 drwxr-xr-x 2 ec2-user ec2-user    25 Jan  5 07:17 META-INF
@@ -89,7 +100,7 @@ file with the command line option `-c`.  Here is a sample of the configuration.
 
 ```groovy
 plugins {
-    id 'nf-float@0.4.1'
+    id 'nf-float'
 }
 
 workDir = '/mnt/memverge/shared'
@@ -172,7 +183,7 @@ Unknown config secret 'MMC_USERNAME'
 To enable s3 as work directory, user need to set work directory to a s3 bucket.
 ```groovy
 plugins {
-    id 'nf-float@0.4.1'
+    id 'nf-float'
 }
 
 workDir = 's3://bucket/path'

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -361,8 +361,8 @@ class FloatGridExecutor extends AbstractGridExecutor {
         getEnv(handler).each { key, val ->
             cmd << '--env' << "${key}=${val}".toString()
         }
+        cmd << '--disableRerun'
         if (isFusionEnabled()) {
-            cmd << '--disableRerun'
             cmd << '--disableMigrate'
             cmd << '--extraContainerOpts'
             cmd << '--privileged'

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.4.1
+Plugin-Version: 0.4.2
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=23.04.0

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
@@ -111,6 +111,7 @@ class FloatBaseTest extends BaseTest {
                 '--cpu', realCpu + ':' + realCpu * FloatConf.DFT_MAX_CPU_FACTOR,
                 '--mem', realMem + ':' + realMem * FloatConf.DFT_MAX_MEM_FACTOR,
                 '--job', script,
+                '--disableRerun',
                 '--customTag', jobID(taskID),
                 '--customTag', "${FloatConf.NF_SESSION_ID}:uuid-$uuid",
                 '--customTag', "${FloatConf.NF_TASK_NAME}:foo--$taskIndex-",


### PR DESCRIPTION
For nextflow jobs, we should disable MMC re-run by default. Because MMC re-run will start in the same directory and may contain files for the last run. We should utilize the re-run of Nextflow instead.

Bump version to 0.4.2