### PR TITLE
[GH-75] Too many `put xxx into map` log

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatBin.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatBin.groovy
@@ -11,6 +11,7 @@ import java.util.regex.Pattern
 @Slf4j
 class FloatBin {
     private static final binName = 'float'
+    private static logged = false
 
     /**
      * This function checks if the float binary is available in the plugin
@@ -38,11 +39,11 @@ class FloatBin {
             }
             ret = targetDir.resolve(binName)
             try {
-                log.info "try downloading $src to $ret"
+                log.info "[FLOAT] try downloading $src to $ret"
                 Global.download(src, ret)
                 ret.setExecutable(true)
             } catch (Exception ex) {
-                log.warn("download ${binName} failed: ${ex.message}")
+                log.warn("[FLOAT] download ${binName} failed: ${ex.message}")
                 return Paths.get(binName)
             }
         }
@@ -67,11 +68,14 @@ class FloatBin {
         for (String path : paths) {
             def floatPath = Paths.get(path).resolve(binName)
             if (Files.exists(floatPath)) {
-                log.info "found float binary in $path"
+                if (!logged) {
+                    log.info "[FLOAT] found float binary in $path"
+                    logged = true
+                }
                 return floatPath
             }
         }
-        log.info "${binName} binary not found"
+        log.warn "[FLOAT] ${binName} binary not found"
         return null
     }
 }

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
@@ -19,7 +19,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.exception.AbortOperationException
 import nextflow.io.BucketParser
-import org.apache.commons.lang.StringUtils
+import nextflow.processor.TaskId
 
 /**
  * @author Cedric Zhuang <cedric.zhuang@memverge.com>
@@ -194,7 +194,7 @@ class FloatConf {
     }
 
     private static void warnDeprecated(String deprecated, String replacement) {
-        log.warn "[float] config option `$deprecated` " +
+        log.warn "[FLOAT] config option `$deprecated` " +
                 "is no longer supported, " +
                 "use `$replacement` instead"
     }
@@ -213,11 +213,13 @@ class FloatConf {
         }
     }
 
-    List<String> getCliPrefix(String address = "") {
-        validate()
-        if (StringUtils.length(address) == 0) {
-            address = addresses[0]
+    List<String> getCliPrefix(TaskId id) {
+        if (id == null) {
+            id = new TaskId(0)
         }
+        final address = addresses[id.intValue() % (addresses.size())]
+        validate()
+
         def bin = FloatBin.get(address)
         List<String> ret = [
                 bin.toString(),
@@ -232,8 +234,8 @@ class FloatConf {
         return ret
     }
 
-    String getCli(String address = "") {
-        return getCliPrefix(address).join(" ")
+    String getCli(TaskId id) {
+        return getCliPrefix(id).join(" ")
     }
 }
 

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.4.3
+Plugin-Version: 0.4.4
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=23.04.0

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatConfTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatConfTest.groovy
@@ -16,6 +16,7 @@
 package com.memverge.nextflow
 
 import nextflow.exception.AbortOperationException
+import nextflow.processor.TaskId
 
 class FloatConfTest extends BaseTest {
     private def bin = FloatBin.get("").toString()
@@ -70,7 +71,7 @@ class FloatConfTest extends BaseTest {
         def fConf = FloatConf.getConf(conf)
 
         then:
-        fConf.getCli() == "${bin} -a 1.2.3.4 " +
+        fConf.getCli(null) == "${bin} -a 1.2.3.4 " +
                 "-u admin -p password"
 
     }
@@ -86,7 +87,7 @@ class FloatConfTest extends BaseTest {
         def fConf = FloatConf.getConf(conf)
 
         then:
-        fConf.getCli("1.1.1.1") == "${bin} -a 1.1.1.1 " +
+        fConf.getCli(new TaskId(1)) == "${bin} -a 2.3.4.5 " +
                 "-u admin -p password"
     }
 

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorMultiOCTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorMultiOCTest.groovy
@@ -38,45 +38,28 @@ class FloatGridExecutorMultiOCTest extends FloatBaseTest {
 
         when:
         def cmd1 = exec.getSubmitCommandLine(
-                newTask(exec), Paths.get(script))
+                newTask(exec, 1), Paths.get(script))
         def cmd2 = exec.getSubmitCommandLine(
-                newTask(exec), Paths.get(script))
-        def expected1 = submitCmd(addr: "fb", taskIndex: 1)
-        def expected2 = submitCmd(addr: "fa", taskIndex: 2)
+                newTask(exec, 2), Paths.get(script))
+        def expected1 = submitCmd(addr: "fb", taskID: 1)
+        def expected2 = submitCmd(addr: "fa", taskID: 2)
 
         then:
         cmd1.join(' ') == expected1.join(' ')
         cmd2.join(' ') == expected2.join(' ')
     }
 
-    def "get queue status commands"() {
-        given:
-        def exec = newTestExecutor()
-
-        when:
-        def cmdMap = exec.queueStatusCommands()
-        def cmd1 = cmdMap['fa']
-        def cmd2 = cmdMap['fb']
-
-        then:
-        cmd1.join(' ') == "${bin} -a fa -u ${user} -p ${pass} " +
-                "list --format json"
-        cmd2.join(' ') == "${bin} -a fb -u ${user} -p ${pass} " +
-                "list --format json"
-    }
-
     def "input multiple addresses as list"() {
         given:
         def exec = newTestExecutor()
-        def task = newTask(exec)
 
         when:
         def cmd1 = exec.getSubmitCommandLine(
-                newTask(exec), Paths.get(script))
+                newTask(exec, 2), Paths.get(script))
         def cmd2 = exec.getSubmitCommandLine(
-                newTask(exec), Paths.get(script))
-        def expected1 = submitCmd(addr: "fa", taskIndex: 2)
-        def expected2 = submitCmd(addr: "fb", taskIndex: 3)
+                newTask(exec, 3), Paths.get(script))
+        def expected1 = submitCmd(addr: "fa", taskID: 2)
+        def expected2 = submitCmd(addr: "fb", taskID: 3)
 
         then:
         cmd1.join(' ') == expected1.join(' ')

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -77,6 +77,18 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "kill commands"() {
         given:
         final exec = newTestExecutor()
+        exec.floatJobs.updateJob(FloatJob.parse(
+            """
+                  id: a
+                  customTags:
+                      nf-job-id: tJob-1
+                  """))
+        exec.floatJobs.updateJob(FloatJob.parse(
+                """
+                  id: b
+                  customTags:
+                      nf-job-id: tJob-2
+                  """))
 
         when:
         final commands = exec.killTaskCommands(['a', 'b'])
@@ -100,7 +112,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                 username: user,
                 password: pass,
                 nfs     : dataVolume]])
-        final task = newTask(exec)
+        final task = newTask(exec, 0)
 
         when:
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
@@ -114,11 +126,11 @@ class FloatGridExecutorTest extends FloatBaseTest {
         given:
         final dataVolume = nfs + ':/data'
         final exec = newTestExecutor([float: [
-                address : addr,
-                maxCpuFactor: 3,
+                address        : addr,
+                maxCpuFactor   : 3,
                 maxMemoryFactor: 2.51,
-                nfs     : dataVolume]])
-        final task = newTask(exec)
+                nfs            : dataVolume]])
+        final task = newTask(exec, 0)
 
         when:
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
@@ -131,7 +143,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "add default local mount point"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec)
+        final task = newTask(exec, 0)
 
         when:
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
@@ -144,7 +156,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "use cpus, memory and container"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 cpus: 8,
                 memory: '16 GB',
                 container: "biocontainers/star"))
@@ -169,7 +181,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          nfs        : nfs,
                          commonExtra: '-t \t small -f ']]
         )
-        final task = newTask(exec)
+        final task = newTask(exec, 0)
 
         when:
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
@@ -188,7 +200,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          nfs        : nfs,
                          commonExtra: '--dataVolume  [opts="-o allow_other"]s3://1.2.3.4:/a:/a  --rootVolSize 10']]
         )
-        final task = newTask(exec)
+        final task = newTask(exec, 0)
 
         when:
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
@@ -205,7 +217,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "add specific extras"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 extra: ' -f -t \t small  ',
                 cpus: 2,
                 memory: "4 G",
@@ -224,7 +236,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "incorrect cpu and memory settings"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 extra: ' -f -t \t small  ',
                 cpu: 2,
                 mem: 4,
@@ -250,7 +262,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          nfs        : nfs,
                          commonExtra: '-t \t small -f ']]
         )
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 extra: '--customTag hello',
                 cpus: 2,
                 memory: "4 G",
@@ -273,7 +285,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
         final cpu = 3
         final mem = 6
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 cpus: cpu,
                 memory: "$mem G",
                 container: image,
@@ -292,7 +304,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "use default nfs and work dir"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec)
+        final task = newTask(exec, 0)
 
         when:
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
@@ -304,7 +316,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "trim space and quotes in image"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 cpus: cpu,
                 memory: "$mem G",
                 container: "\"' $image\t'\"",
@@ -321,7 +333,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "parse data volume"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 cpus: cpu,
                 memory: "$mem G",
                 container: image,
@@ -341,7 +353,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "use machine type directive"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 machineType: 't2.xlarge',
         ))
@@ -356,7 +368,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "use disk directive"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 disk: '41G',
         ))
@@ -371,7 +383,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "use time directive"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 time: '24h',
         ))
@@ -391,7 +403,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          password  : pass,
                          nfs       : nfs,
                          timeFactor: 1.1]])
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 time: '1h',
         ))
@@ -410,7 +422,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          username: user,
                          password: pass,
                          nfs     : nfs]])
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 time: '1h',
                 attempt: 2,
@@ -431,7 +443,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          password : pass,
                          nfs      : nfs,
                          cpuFactor: 1.5]])
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 cpus: 2,
         ))
@@ -451,7 +463,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          password : pass,
                          nfs      : nfs,
                          cpuFactor: 0.2]])
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 cpus: 1,
         ))
@@ -471,7 +483,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          password    : pass,
                          nfs         : nfs,
                          memoryFactor: 0.5]])
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 memory: "8 GB",
         ))
@@ -491,7 +503,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          password    : pass,
                          nfs         : nfs,
                          memoryFactor: 0.5]])
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 memory: 8,
         ))
@@ -512,7 +524,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                         password    : pass,
                         nfs         : nfs,
                         extraOptions: option]])
-        final task = newTask(exec)
+        final task = newTask(exec, 0)
 
         when:
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
@@ -525,7 +537,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "use resourceLabels directive"() {
         given:
         final exec = newTestExecutor()
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 resourceLabels: [foo: 'bar'],
         ))
@@ -537,18 +549,15 @@ class FloatGridExecutorTest extends FloatBaseTest {
         cmd.join(' ').contains('--customTag foo:bar')
     }
 
-    private def taskStatus(int i, String st) {
+    private static def taskStatus(int i, String st) {
         return """
-            {
-                "id": "task$i",
-                "name": "tJob-$i",
-                "user": "admin",
-                "imageID": "docker.io/memverge/cactus:latest",
-                "status": "$st",
-                "customTags": {
-                    "nf-job-id": "tJob-$i"
-                }
-            }
+                id: task$i,
+                name: tJob-$i
+                user: admin
+                imageID: docker.io/memverge/cactus:latest,
+                status: $st,
+                customTags:
+                    nf-job-id: tJob-$i
             """
     }
 
@@ -571,31 +580,19 @@ class FloatGridExecutorTest extends FloatBaseTest {
                 12: "Resuming",
                 13: "Capturing",
         ]
-        def statusList = []
-        for (def item : taskMap.entrySet()) {
-            statusList.add(taskStatus(item.key, item.value))
-        }
-        final text = "[" + statusList.join(",") + "]".stripIndent()
 
         when:
-        final count = taskMap.size() - 1
-        (0..count).forEach {
-            def task = newTask(exec)
-            task.workDir = Paths.get(
-                    'src', 'test', 'com', 'memverge', 'nextflow')
-            task.id = new TaskId(it)
-            exec.getHeaderScript(task)
+        final count = taskMap.size()
+        // update a list of the task status
+        for ( def entry : taskMap.entrySet()) {
+            exec.floatJobs.updateJob(FloatJob.parse(taskStatus(entry.key, entry.value)))
         }
-
-
-        def dir = Paths.get('src', 'test', 'com', 'memverge')
-        exec.floatJobs.setWorkDir(new TaskId(8), dir)
-        def res = exec.parseQueueStatus(text)
+        def res = exec.parseQueueStatus("")
 
         then:
         //noinspection GroovyAccessibility
         def qs = AbstractGridExecutor.QueueStatus
-        res.size() == count + 1
+        res.size() == count
         res['tJob-0'] == qs.PENDING
         res['tJob-1'] == qs.PENDING
         res['tJob-2'] == qs.RUNNING
@@ -620,10 +617,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
         def cmd = exec.queueStatusCommand(null)
 
         then:
-        cmd == [bin, '-a', addr,
-                '-u', user,
-                '-p', pass,
-                'list', '--format', 'json']
+        cmd == []
     }
 
     def "retrieve the credentials from env"() {
@@ -637,7 +631,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          nfs: nfs]])
 
 
-        final task = newTask(exec, new TaskConfig(
+        final task = newTask(exec, 0, new TaskConfig(
                 cpus: cpu,
                 memory: "$mem G",
                 container: image))


### PR DESCRIPTION
The old implementation list all jobs in the opCenter which is unnecessary.  We should only focus on the job submitted by the plugin.

Remove the full poll in the queue status update.  Add the job entry when we submit it.

Remove the code related to the full job poll and clean up the logs.