### PR TITLE
[GH-69] Support `float` in `ext` directive`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ process {
   center and the proper credentials.
 * In the `process` scope, we specify `executor = 'float'` to tell Nextflow to execute
   tasks with the Float executor.
+* In the `process` scope, we can use `ext.float = 'xxx'` to pass extra options to the 
+  float command line.  It works the same as `extra`.
 
 Available `float` config options: 
 
@@ -181,7 +183,7 @@ Unknown config secret 'MMC_USERNAME'
 ### Configure s3 work directory
 
 To enable s3 as work directory, user need to set work directory to a s3 bucket.
-Note `token` is optional.  If you don't have a token, you can leave it empty.
+Note `token` is not supported.
 ```groovy
 plugins {
     id 'nf-float'
@@ -206,7 +208,6 @@ float {
 aws {
   accessKey = '***'
   secretKey = '***'
-  token = '***'
   region = 'us-east-2'
 }
 ```
@@ -214,12 +215,10 @@ aws {
 You don't need to specify `nfs` in `float` scope.  The plugin will assemble
 the `nfs` option automatically.
 
-The plugin retrieves the s3 credentials from Nextflow.
-Nextflow looks for AWS credentials in the following order:
+The plugin retrieves the s3 credentials in the following order:
 * the `nextflow.config` file in the pipeline execution directory
 * read key from `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY_ID`
 * read secret from `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY`
-* read token from `AWS_TOKEN` or `AWS_SESSION_TOKEN` if applicable
 * the default profile in the AWS credentials file located at `~/.aws/credentials`
 * the default profile in the AWS client configuration file located at `~/.aws/config`
 * the temporary AWS credentials provided by an IAM instance role. See IAM Roles documentation for details.
@@ -231,6 +230,49 @@ Tests done for s3 work directory support:
 * trivial sequence and scatter workflow.
 * the test profile of nf-core/rnaseq
 * the test profile of nf-core/sarek
+
+### Configure s3fs work directory
+
+To enable s3fs as work directory, user need to set work directory to a s3 bucket.
+Note `token` is optional.  If you don't have a token, you can leave it empty.
+```groovy
+plugins {
+    id 'nf-float'
+}
+
+workDir = '/s3/bucket'
+
+process {
+    executor = 'float'
+    container = 'fedora/fedora-minimal'
+}
+
+podman.registry = 'quay.io'
+
+float {
+    address = 'op.center.address'
+    username = secrets.MMC_USERNAME
+    password = secrets.MMC_PASSWORD
+    nfs = 's3://bucket:/s3/bucket'
+    timeFactor = 2
+}
+
+aws {
+  accessKey = '***'
+  secretKey = '***'
+  token = '***'
+  region = 'us-east-2'
+}
+```
+
+The plugin retrieves the s3 credentials in the following order:
+* the `nextflow.config` file in the pipeline execution directory
+* read key from `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY_ID`
+* read secret from `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY`
+* read token from `AWS_TOKEN` or `AWS_SESSION_TOKEN` if applicable
+* the default profile in the AWS credentials file located at `~/.aws/credentials`
+* the default profile in the AWS client configuration file located at `~/.aws/config`
+* the temporary AWS credentials provided by an IAM instance role. See IAM Roles documentation for details.
 
 
 ### Configure fusion FS over s3

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -134,13 +134,20 @@ class FloatGridExecutor extends AbstractGridExecutor {
     }
 
     private Collection<String> getExtra(TaskRun task) {
-        final extraNode = task.config.extra
-        def extra = extraNode ? extraNode as String : ''
+        List<String> extras = []
         final common = floatConf.commonExtra
         if (common) {
-            extra = common.trim() + " " + extra.trim()
+            extras.add(common.trim())
         }
-        def ret = splitWithQuotes(extra)
+        final extraNode = task.config.extra
+        if (extraNode) {
+            extras.add((extraNode as String).trim())
+        }
+        final extFloat = task.config.ext?['float']
+        if (extFloat) {
+            extras.add((extFloat as String).trim())
+        }
+        def ret = splitWithQuotes(extras.join(' '))
         return ret.findAll { it.length() > 0 }
     }
 

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -280,6 +280,29 @@ class FloatGridExecutorTest extends FloatBaseTest {
         cmd.join(' ') == expected.join(' ')
     }
 
+    def "define both common extra and ext float"() {
+        given:
+        final exec = newTestExecutor(
+                [float: [address    : addr,
+                         username   : user,
+                         password   : pass,
+                         nfs        : nfs,
+                         commonExtra: '-f']]
+        )
+        final task = newTask(exec, 0, new TaskConfig(
+                ext: [float: '-t small'],
+                cpus: 2,
+                memory: "4 G",
+                container: image))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+        final expected = submitCmd(cpu: 2, memory: 4) + ['-f', '-t', 'small']
+
+        then:
+        cmd.join(' ') == expected.join(' ')
+    }
+
     def "config level cpu and memory"() {
         given:
         final cpu = 3


### PR DESCRIPTION
As suggested in https://github.com/MemVerge/nf-float/issues/69, it's not a common practice to use `extra = 'xxx'` in a process.

Allow user to specify extra options in `process.ext.float`.