### PR TITLE
[GH-63] Ignore the time limit by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Available `float` config options:
               the CLI usage for the list of available options.
 * `vmPolicy`: the VM creation policy, specified as a map.  Refer to the CLI usage
               for the list of available options.
+* `ignoreTimeLimits`: a boolean.  default to true.  If set to true, the plugin will ignore
+  the time limit of the task.
 * `timeFactor`: a float number.  default to 1.  An extra factor to multiply based 
   on the time supplied by the task.  Add time factor to enlarge the default timeout of the task.  
   Because WaveRider may take extra time for job migration.

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatConf.groovy
@@ -56,6 +56,7 @@ class FloatConf {
     String migratePolicy
     String extraOptions
     String commonExtra
+    boolean ignoreTimeFactor = true
 
     float timeFactor = 1
     float cpuFactor = 1
@@ -165,6 +166,9 @@ class FloatConf {
         }
         if (floatNode.memoryFactor) {
             this.memoryFactory = floatNode.memoryFactor as Float
+        }
+        if (floatNode.containsKey('ignoreTimeFactor')) {
+            this.ignoreTimeFactor = floatNode.ignoreTimeFactor as Boolean
         }
         this.commonExtra = floatNode.commonExtra
 

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -361,7 +361,7 @@ class FloatGridExecutor extends AbstractGridExecutor {
             cmd << '--instType' << task.config.getMachineType()
         }
         addVolSize(cmd, task)
-        if (task.config.getTime()) {
+        if (!floatConf.ignoreTimeFactor && task.config.getTime()) {
             Float seconds = task.config.getTime().toSeconds()
             seconds *= floatConf.timeFactor
             cmd << '--timeLimit' << "${seconds.toInteger()}s".toString()

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -403,9 +403,30 @@ class FloatGridExecutorTest extends FloatBaseTest {
         cmd.join(' ').contains('--imageVolSize 41')
     }
 
-    def "use time directive"() {
+    def "by default, ignore the time directive"() {
         given:
         final exec = newTestExecutor()
+        final task = newTask(exec, 0, new TaskConfig(
+                container: image,
+                time: '24h',
+        ))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        !cmd.join(' ').contains('--timeLimit')
+    }
+
+    def "use time directive"() {
+        given:
+        final exec = newTestExecutor([
+                float: [address: addr,
+                        username: user,
+                        password: pass,
+                        nfs: nfs,
+                        ignoreTimeFactor: false]
+        ])
         final task = newTask(exec, 0, new TaskConfig(
                 container: image,
                 time: '24h',
@@ -425,6 +446,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
                          username  : user,
                          password  : pass,
                          nfs       : nfs,
+                         ignoreTimeFactor: false,
                          timeFactor: 1.1]])
         final task = newTask(exec, 0, new TaskConfig(
                 container: image,


### PR DESCRIPTION
Add a `ignoreTimeLimits` option in float and default to true. If user want to enable time limit, he/she needs to explicitly set this option to `false`.