### PR TITLE
[GH-87] Log parsing error for job ID

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatJob.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatJob.groovy
@@ -105,6 +105,9 @@ class FloatJob {
         ret.status = FloatStatus.of(status)
         ret.floatJobID = floatID
         ret.rc = rc
+        if (!ret.nfJobID) {
+            log.warn "[FLOAT] failed to parse nfJobID from: ${input}"
+        }
         return ret
     }
 

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -58,6 +58,17 @@ class FloatGridExecutorTest extends FloatBaseTest {
         job.status == FloatStatus.PENDING
     }
 
+    def "parse job id failed"() {
+        given:
+        def exec = newTestExecutor()
+
+        when:
+        final out = "Error: open abc.sh: no such file or directory"
+
+        then:
+        exec.parseJobId(out) == ""
+    }
+
     def "kill command"() {
         given:
         def exec = newTestExecutor()


### PR DESCRIPTION
Log the output of the submit command when we failed to parse job ID for further analysis.