### PR TITLE
[GH-89] Use default disk size of MMC

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -439,15 +439,18 @@ class FloatGridExecutor extends AbstractGridExecutor {
         if (disk) {
             size = Math.max(size, disk.toGiga())
         }
-        if (isFusionEnabled()) {
+        final fusionEnabled = isFusionEnabled()
+        if (fusionEnabled) {
             size = Math.max(size, FUSION_MIN_VOL_SIZE)
         }
-        if (task.scratch) {
+        if (task.scratch || fusionEnabled) {
             double inputSizeGB = (double) (getInputFileSize(task)) / 1024 / 1024 / 1024
             long minDiskSizeBasedOnInput = Math.round(inputSizeGB * DISK_INPUT_FACTOR)
             size = Math.max(size, minDiskSizeBasedOnInput)
         }
-        cmd << '--imageVolSize' << size.toString()
+        if (size > FloatConf.MIN_VOL_SIZE) {
+            cmd << '--imageVolSize' << size.toString()
+        }
     }
 
     /**

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
@@ -121,7 +121,6 @@ class FloatBaseTest extends BaseTest {
                 '--customTag', "${FloatConf.NF_SESSION_ID}:uuid-$uuid",
                 '--customTag', "${FloatConf.NF_TASK_NAME}:foo--$taskIDStr-",
                 '--customTag', "${FloatConf.FLOAT_INPUT_SIZE}:0",
-                '--customTag', "${FloatConf.NF_RUN_NAME}:test-run",
-                '--imageVolSize', FloatConf.MIN_VOL_SIZE]
+                '--customTag', "${FloatConf.NF_RUN_NAME}:test-run"]
     }
 }

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -714,7 +714,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
         exec.addVolSize(cmd, task)
 
         then:
-        cmd.join(' ') == "--imageVolSize ${FloatConf.MIN_VOL_SIZE}"
+        cmd.join(' ') == ""
     }
 
     def "get disk size when specified in task"() {
@@ -740,6 +740,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
         exec.addVolSize(cmd, task)
 
         then:
-        cmd.join(' ') == "--imageVolSize ${FloatConf.MIN_VOL_SIZE}"
+        // do not specify size because it's smaller than min
+        cmd.join(' ') == ""
     }
 }


### PR DESCRIPTION
When user does not specify a disk size and the (total input size * 5) is smaller than 6 GB, we should not hard code the disk size to 6 GB. Instead, we should allow MMC to calculate the disk size.