### PR TITLE
[GH-91] default file stage in strategy to copy

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -103,14 +103,14 @@ class FloatGridExecutor extends AbstractGridExecutor {
 
     protected BashWrapperBuilder createBashWrapperBuilder(TaskRun task) {
         final bean = new TaskBean(task)
+        if (bean.scratch == null) {
+            // default scratch to true
+            bean.scratch = true
+            bean.stageInMode = 'copy'
+        }
         final strategy = new FloatFileCopyStrategy(floatConf, bean)
         // creates the wrapper script
         final builder = new BashWrapperBuilder(bean, strategy)
-        if (builder.scratch == null) {
-            // default scratch to true
-            builder.scratch = true
-            builder.stageInMode = 'copy'
-        }
         // job directives headers
         builder.headerScript = getHeaderScript(task)
         return builder


### PR DESCRIPTION
As title.  If scratch is not specified, default to true and set the stage in strategy to copy to avoid symbolic link between local filesystem and s3fs.