### PR TITLE
[GH-95] Do not enable `scratch` for local workdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ process {
 
 To enable s3 as work directory, user need to set work directory to a s3 bucket.
 Note `token` is not supported.
+Note `scratch` is enabled by default.  If you want to disable it, please set `scratch = false`.
+`stageInMode` is set to `copy` by default.  If you want to disable it, please set `stageInMode = 'link'`.
+
 ```groovy
 plugins {
     id 'nf-float'
@@ -238,8 +241,6 @@ process {
     executor = 'float'
     container = 'fedora/fedora-minimal'
     disk = '120 GB'
-    scratch = true
-    stageInMode = 'copy'
 }
 
 podman.registry = 'quay.io'
@@ -276,7 +277,8 @@ Tests done for s3 work directory support:
 * the test profile of nf-core/rnaseq
 * the test profile of nf-core/sarek
 
-By default, `scratch` option is set to true, `stageInMode` is set to `copy`.
+By default, `scratch` option is set to true, `stageInMode` is set to `copy` for network file system
+such as `s3`.
 When `scratch` is enabled, the plugin will use the scratch space of the worker node to store the task 
 files.  This is useful when the task files are large and the network bandwidth is limited.
 

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -103,7 +103,7 @@ class FloatGridExecutor extends AbstractGridExecutor {
 
     protected BashWrapperBuilder createBashWrapperBuilder(TaskRun task) {
         final bean = new TaskBean(task)
-        if (bean.scratch == null) {
+        if (useNetworkWorkdir() && bean.scratch == null) {
             // default scratch to true
             bean.scratch = true
             bean.stageInMode = 'copy'
@@ -274,6 +274,10 @@ class FloatGridExecutor extends AbstractGridExecutor {
         if (task.config.image) {
             warnDeprecated('image', '`container` directive')
         }
+    }
+
+    private useNetworkWorkdir() {
+        return workDir.getScheme() != "file"
     }
 
     private List<String> getMountVols(TaskRun task) {

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -747,6 +747,9 @@ class FloatGridExecutorTest extends FloatBaseTest {
     def "default scratch to true, stage in mode to copy"() {
         given:
         final exec = newTestExecutor()
+        URL workDirUrl = new URL("https://work/dir");
+        URI workDirUri = workDirUrl.toURI();
+        exec.session.workDir = Paths.get(workDirUri)
         final task = newTask(exec, 0)
 
         when:
@@ -755,6 +758,36 @@ class FloatGridExecutorTest extends FloatBaseTest {
         then:
         builder.scratch == true
         builder.stageInMode == 'copy'
+    }
+
+    def "default scratch to false for local path"() {
+        given:
+        final exec = newTestExecutor()
+        exec.session.workDir = Paths.get('/local/workDir')
+        final task = newTask(exec, 0)
+
+        when:
+        def builder = exec.createBashWrapperBuilder(task)
+
+        then:
+        builder.scratch == null
+        builder.stageInMode == null
+    }
+
+    def "default scratch to false for local url"() {
+        given:
+        final exec = newTestExecutor()
+        URL workDirUrl = new URL("file:///work/dir");
+        URI workDirUri = workDirUrl.toURI();
+        exec.session.workDir = Paths.get(workDirUri)
+        final task = newTask(exec, 0)
+
+        when:
+        def builder = exec.createBashWrapperBuilder(task)
+
+        then:
+        builder.scratch == null
+        builder.stageInMode == null
     }
 
     def "use custom scratch and stage in mode"() {


### PR DESCRIPTION
For local work directory, do not change the default scratch option.