### PR TITLE
[GH-106][PER-9] Fixed an issue where an unusual mem spec caused the task submission to fail

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -403,7 +403,7 @@ fi
         int cpu = getCpu(task)
         int maxCpu = (floatConf.maxCpuFactor * cpu.doubleValue()).intValue()
         cmd << '--cpu' << "${cpu}:${maxCpu}".toString()
-        int memGiga = getMemory(task)
+        int memGiga = Math.max(getMemory(task), cpu * 2)
         int maxMemGiga = (floatConf.maxMemoryFactor * memGiga.doubleValue()).intValue()
         cmd << '--mem' << "${memGiga}:${maxMemGiga}".toString()
         cmd << '--job' << getScriptFilePath(handler, scriptFile)

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -258,10 +258,29 @@ class FloatGridExecutorTest extends FloatBaseTest {
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
         final expected = submitCmd(
                 cpu: 1,
-                memory: 1) + ['-f', '-t', 'small']
+                memory: 2) + ['-f', '-t', 'small']
 
         then:
         cmd.join(' ') == expected.join(' ')
+    }
+
+    def "incorrect cpu and memory ratio"() {
+        given:
+        final exec = newTestExecutor(
+                [float: [address        : addr,
+                         maxCpuFactor   : 4,
+                         maxMemoryFactor: 4]])
+        final task = newTask(exec, 0, new TaskConfig(
+                cpus: 12,
+                memory: "4.GB",
+                container: 'fastp'
+        ))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd.join(' ').contains("--cpu 12:48 --mem 24:96")
     }
 
     def "both common extra and specific extra"() {
@@ -568,7 +587,7 @@ class FloatGridExecutorTest extends FloatBaseTest {
         final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
 
         then:
-        cmd.join(' ').contains('--mem 1')
+        cmd.join(' ').contains('--mem 2')
     }
 
     def "use extra options"() {


### PR DESCRIPTION
Closes #106 

No task can be submitted with a Mem/CPU ratio < 2 as each task gets its own instance on MM Cloud. Such instances are not available on AWS and that leads to task submission failure.

The applied fix applies a lower bound to the memory spec. of a task based on its CPU spec. If the memory spec. is lower than 2 x CPU spec., it is bumped to 2 x CPU.

I have not applied a version bump to the plugin. I was not sure of the release workflow.

Thank you!

P.S.

A more sophisticated/conservative lower bound is also possible such as,

```groovy
int maxMemGiga = Math.max( (floatConf.maxMemoryFactor * memGiga.doubleValue()).intValue(), cpu * 2 )
```

This approach ensures that at least the upper limit of the memory is always greater or equal to  2 x CPU. But this strategy shrinks the permissible set of spot instances and can create its own problems in low spot availability zones.