### PR TITLE
[GH-105] Added support for the accelerator directive

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -382,6 +382,16 @@ fi
         return Math.max(ret, 1)
     }
 
+    private static Integer getAccelerator(TaskRun task) {
+        final accelRes = task.config.getAccelerator()
+
+        if (accelRes == null) {
+            return 0
+        }
+
+        return Math.max(0, accelRes.request)
+    }
+
     List<String> getSubmitCommandLine(FloatTaskHandler handler, Path scriptFile) {
         final task = handler.task
 
@@ -406,6 +416,10 @@ fi
         int memGiga = Math.max(getMemory(task), cpu * 2)
         int maxMemGiga = (floatConf.maxMemoryFactor * memGiga.doubleValue()).intValue()
         cmd << '--mem' << "${memGiga}:${maxMemGiga}".toString()
+        int accelerator = getAccelerator(task)
+        if (accelerator>0) {
+            cmd << '--gpu-count' << accelerator.toString()
+        }
         cmd << '--job' << getScriptFilePath(handler, scriptFile)
         getEnv(handler).each { key, val ->
             cmd << '--env' << "${key}=${val}".toString()

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.4.7
+Plugin-Version: 0.4.8
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=23.04.0

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatBaseTest.groovy
@@ -107,7 +107,9 @@ class FloatBaseTest extends BaseTest {
         Integer taskID = Integer.parseInt(taskIDStr)
         def realCpu = param.cpu ?: cpu
         def realMem = param.memory ?: mem
-        return [bin, '-a', param.addr ?: addr,
+        return [
+                bin, '-a',
+                param.addr ?: addr,
                 '-u', user,
                 '-p', pass,
                 'submit',
@@ -115,12 +117,14 @@ class FloatBaseTest extends BaseTest {
                 '--image', param.image ?: image,
                 '--cpu', realCpu + ':' + realCpu * FloatConf.DFT_MAX_CPU_FACTOR,
                 '--mem', realMem + ':' + realMem * FloatConf.DFT_MAX_MEM_FACTOR,
+                param.accelerator ? "--gpu-count ${param.accelerator}": null,
                 '--job', script,
                 '--disableRerun',
                 '--customTag', jobID(new TaskId(taskID)),
                 '--customTag', "${FloatConf.NF_SESSION_ID}:uuid-$uuid",
                 '--customTag', "${FloatConf.NF_TASK_NAME}:foo--$taskIDStr-",
                 '--customTag', "${FloatConf.FLOAT_INPUT_SIZE}:0",
-                '--customTag', "${FloatConf.NF_RUN_NAME}:test-run"]
+                '--customTag', "${FloatConf.NF_RUN_NAME}:test-run"
+        ].findAll { it != null }
     }
 }

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorTest.groovy
@@ -183,6 +183,48 @@ class FloatGridExecutorTest extends FloatBaseTest {
         cmd.join(' ') == expected.join(' ')
     }
 
+    def "use cpus, memory, accelerator and container"() {
+        given:
+        final exec = newTestExecutor()
+        final task = newTask(exec, 0, new TaskConfig(
+                cpus: 8,
+                memory: '16 GB',
+                accelerator: 4,
+                container: "biocontainers/star"))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+        final expected = submitCmd(
+                cpu: 8,
+                memory: 16,
+                accelerator: 4,
+                image: "biocontainers/star")
+
+        then:
+        cmd.join(' ') == expected.join(' ')
+    }
+
+    def "use cpus, memory, accelerator type and container"() {
+        given:
+        final exec = newTestExecutor()
+        final task = newTask(exec, 0, new TaskConfig(
+                cpus: 8,
+                memory: '16 GB',
+                accelerator: [request: 2, type: 'nvidia-tesla-k80'],
+                container: "biocontainers/star"))
+
+        when:
+        final cmd = exec.getSubmitCommandLine(task, Paths.get(script))
+        final expected = submitCmd(
+                cpu: 8,
+                memory: 16,
+                accelerator: 2,
+                image: "biocontainers/star")
+
+        then:
+        cmd.join(' ') == expected.join(' ')
+    }
+
     def "add common extras"() {
         given:
         final exec = newTestExecutor(


### PR DESCRIPTION
With this change, users can request for a GPU machine by simply specifying the accelerator directive such as,

```groovy
process {
    withName: 'PARABRICKS_FQ2BAMMETH' {
        accelerator = 1
    }
}
```

nf-float will translate that into `float submit ... --gpu-count 1 ...`